### PR TITLE
fix(templates): eliminate duplicate HTML document structure on all pages

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -52,7 +52,6 @@
     --color-blue-600: oklch(54.6% 0.245 262.881);
     --color-blue-700: oklch(48.8% 0.243 264.376);
     --color-blue-900: oklch(37.9% 0.146 265.522);
-    --color-purple-400: oklch(71.4% 0.203 305.504);
     --color-slate-200: oklch(92.9% 0.013 255.508);
     --color-slate-300: oklch(86.9% 0.022 252.894);
     --color-slate-400: oklch(70.4% 0.04 256.788);
@@ -133,11 +132,14 @@
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
+    --color-wow-error: #e74c3c;
+    --color-wow-success: #2ecc71;
     --color-gold-400: #fbbf24;
     --color-gold-500: #f59e0b;
     --color-gold-600: #d97706;
     --color-gold-800: #92400e;
     --font-cinzel: Cinzel, serif;
+    --border-width-3: 3px;
   }
 }
 @layer base {
@@ -366,11 +368,11 @@
   .top-4 {
     top: calc(var(--spacing) * 4);
   }
+  .top-18 {
+    top: calc(var(--spacing) * 18);
+  }
   .top-38 {
     top: calc(var(--spacing) * 38);
-  }
-  .top-\[72px\] {
-    top: 72px;
   }
   .top-full {
     top: 100%;
@@ -705,6 +707,9 @@
   .max-h-24 {
     max-height: calc(var(--spacing) * 24);
   }
+  .max-h-30 {
+    max-height: calc(var(--spacing) * 30);
+  }
   .max-h-40 {
     max-height: calc(var(--spacing) * 40);
   }
@@ -717,26 +722,23 @@
   .max-h-\[90vh\] {
     max-height: 90vh;
   }
-  .max-h-\[120px\] {
-    max-height: 120px;
-  }
   .max-h-full {
     max-height: 100%;
+  }
+  .min-h-14 {
+    min-height: calc(var(--spacing) * 14);
+  }
+  .min-h-20 {
+    min-height: calc(var(--spacing) * 20);
+  }
+  .min-h-35 {
+    min-height: calc(var(--spacing) * 35);
   }
   .min-h-\[42px\] {
     min-height: 42px;
   }
   .min-h-\[55px\] {
     min-height: 55px;
-  }
-  .min-h-\[56px\] {
-    min-height: 56px;
-  }
-  .min-h-\[80px\] {
-    min-height: 80px;
-  }
-  .min-h-\[140px\] {
-    min-height: 140px;
   }
   .min-h-\[180px\] {
     min-height: 180px;
@@ -810,6 +812,9 @@
   .w-64 {
     width: calc(var(--spacing) * 64);
   }
+  .w-70 {
+    width: calc(var(--spacing) * 70);
+  }
   .w-72 {
     width: calc(var(--spacing) * 72);
   }
@@ -818,9 +823,6 @@
   }
   .w-\[52px\] {
     width: 52px;
-  }
-  .w-\[280px\] {
-    width: 280px;
   }
   .w-auto {
     width: auto;
@@ -842,6 +844,9 @@
   }
   .max-w-7xl {
     max-width: var(--container-7xl);
+  }
+  .max-w-350 {
+    max-width: calc(var(--spacing) * 350);
   }
   .max-w-\[50px\] {
     max-width: 50px;
@@ -885,14 +890,14 @@
   .min-w-0 {
     min-width: 0px;
   }
+  .min-w-12 {
+    min-width: calc(var(--spacing) * 12);
+  }
+  .min-w-25 {
+    min-width: calc(var(--spacing) * 25);
+  }
   .min-w-\[42px\] {
     min-width: 42px;
-  }
-  .min-w-\[48px\] {
-    min-width: 48px;
-  }
-  .min-w-\[100px\] {
-    min-width: 100px;
   }
   .min-w-\[110px\] {
     min-width: 110px;
@@ -1244,9 +1249,9 @@
     border-left-style: var(--tw-border-style);
     border-left-width: 2px;
   }
-  .border-l-\[3px\] {
+  .border-l-3 {
     border-left-style: var(--tw-border-style);
-    border-left-width: 3px;
+    border-left-width: var(--border-width-3);
   }
   .border-dashed {
     --tw-border-style: dashed;
@@ -1263,6 +1268,9 @@
   }
   .border-\[\#c9a227\]\/20 {
     border-color: color-mix(in oklab, #c9a227 20%, transparent);
+  }
+  .border-\[\#c9a227\]\/22 {
+    border-color: color-mix(in oklab, #c9a227 22%, transparent);
   }
   .border-\[\#c9a227\]\/30 {
     border-color: color-mix(in oklab, #c9a227 30%, transparent);
@@ -1532,6 +1540,18 @@
     border-color: color-mix(in srgb, #fff 5%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       border-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+    }
+  }
+  .border-wow-error\/40 {
+    border-color: color-mix(in srgb, #e74c3c 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-wow-error) 40%, transparent);
+    }
+  }
+  .border-wow-success\/40 {
+    border-color: color-mix(in srgb, #2ecc71 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-wow-success) 40%, transparent);
     }
   }
   .border-yellow-500\/50 {
@@ -1915,6 +1935,18 @@
   .bg-transparent {
     background-color: transparent;
   }
+  .bg-wow-error\/15 {
+    background-color: color-mix(in srgb, #e74c3c 15%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-wow-error) 15%, transparent);
+    }
+  }
+  .bg-wow-success\/15 {
+    background-color: color-mix(in srgb, #2ecc71 15%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-wow-success) 15%, transparent);
+    }
+  }
   .bg-yellow-900\/20 {
     background-color: color-mix(in srgb, oklch(42.1% 0.095 57.708) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1933,6 +1965,13 @@
       background-color: color-mix(in oklab, var(--color-yellow-900) 40%, transparent);
     }
   }
+  .bg-linear-to-b {
+    --tw-gradient-position: to bottom;
+    @supports (background-image: linear-gradient(in lab, red, red)) {
+      --tw-gradient-position: to bottom in oklab;
+    }
+    background-image: linear-gradient(var(--tw-gradient-stops));
+  }
   .bg-gradient-to-b {
     --tw-gradient-position: to bottom in oklab;
     background-image: linear-gradient(var(--tw-gradient-stops));
@@ -1944,6 +1983,9 @@
   .bg-gradient-to-r {
     --tw-gradient-position: to right in oklab;
     background-image: linear-gradient(var(--tw-gradient-stops));
+  }
+  .bg-\[linear-gradient\(180deg\,\#fff7d6_0\%\,\#f2cf5b_35\%\,\#c9a227_62\%\,\#8a6a14_100\%\)\] {
+    background-image: linear-gradient(180deg,#fff7d6 0%,#f2cf5b 35%,#c9a227 62%,#8a6a14 100%);
   }
   .from-\[\#0a0e16\] {
     --tw-gradient-from: #0a0e16;
@@ -2522,6 +2564,9 @@
   .break-words {
     overflow-wrap: break-word;
   }
+  .wrap-anywhere {
+    overflow-wrap: anywhere;
+  }
   .whitespace-nowrap {
     white-space: nowrap;
   }
@@ -2758,6 +2803,12 @@
   }
   .text-white {
     color: var(--color-white);
+  }
+  .text-wow-error {
+    color: var(--color-wow-error);
+  }
+  .text-wow-success {
+    color: var(--color-wow-success);
   }
   .text-yellow-200 {
     color: var(--color-yellow-200);
@@ -3963,6 +4014,9 @@
     }
     .lg\:ml-0 {
       margin-left: 0px;
+    }
+    .lg\:ml-70 {
+      margin-left: calc(var(--spacing) * 70);
     }
     .lg\:ml-\[280px\] {
       margin-left: 280px;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "phpmailer/phpmailer": "^6.10"
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^2.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb5da62d73716ac8a1776f19367bc28f",
+    "content-hash": "c9a756e7e858f1501748cb8efe6d553b",
     "packages": [
         {
             "name": "phpmailer/phpmailer",
@@ -88,7 +88,72 @@
             "time": "2025-04-24T15:19:31+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.13",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
+                "reference": "9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-09-03T20:38:19+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
@@ -96,5 +161,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/download/index.php
+++ b/download/index.php
@@ -54,21 +54,12 @@ if (is_dir($download_dir)) {
 }
 
 $page_class = 'download';
-include_once $project_root . 'includes/header.php';
+$page_title = $site_title_name . " " . translate('download_title', 'Download');
+$page_meta_description = translate('download_meta_description', 'Download Wrath of the Lich King client for Sahtout WoW Server');
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('download_meta_description', 'Download Wrath of the Lich King client for Sahtout WoW Server'); ?>">
-    <title><?php echo $site_title_name . " " . translate('download_title', 'Download'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
-    <style>
+<style>
         * { font-family: 'Inter', sans-serif; }
 
         /* Fix footer to bottom */
@@ -300,8 +291,10 @@ include_once $project_root . 'includes/header.php';
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+include_once $project_root . 'includes/header.php';
+?>
     <!-- Header is included at the top via include_once -->
 
     <!-- Main content wrapper -->
@@ -509,5 +502,3 @@ include_once $project_root . 'includes/header.php';
     </script>
 
     <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/includes/admin_sidebar.php
+++ b/includes/admin_sidebar.php
@@ -211,7 +211,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
 </button>
 
 <!-- Mobile Sidebar Overlay -->
-<div id="sidebarOverlay" class="fixed top-[72px] left-0 right-0 bottom-0 bg-black/60 backdrop-blur-sm z-30 opacity-0 pointer-events-none transition-opacity duration-300 lg:hidden"></div>
+<div id="sidebarOverlay" class="fixed top-18 left-0 right-0 bottom-0 bg-black/60 backdrop-blur-sm z-30 opacity-0 pointer-events-none transition-opacity duration-300 lg:hidden"></div>
 
 <!-- Desktop Toggle Button -->
 <button id="sidebarToggleBtn" aria-label="Toggle sidebar" 
@@ -221,20 +221,20 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
            text-[#f2cf5b] hover:bg-[rgba(201,162,39,.15)] hover:text-white hover:shadow-[0_0_20px_rgba(201,162,39,.2)]
            transition-all duration-300 ease-in-out group backdrop-blur-sm"
     style="left: 280px;">
-    <div class="absolute top-2 bottom-2 left-0 w-px bg-gradient-to-b from-transparent via-[rgba(201,162,39,.4)] to-transparent"></div>
+    <div class="absolute top-2 bottom-2 left-0 w-px bg-linear-to-b from-transparent via-[rgba(201,162,39,.4)] to-transparent"></div>
     <i class="fas fa-chevron-left text-xs transition-transform duration-300 group-hover:scale-125" id="toggleIcon"></i>
     <div class="absolute inset-0 rounded-r-lg bg-[rgba(201,162,39,.1)] opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none"></div>
 </button>
 
 <!-- Sidebar -->
 <aside id="adminSidebar" 
-       class="fixed top-[72px] left-0 bottom-0 w-[280px] z-40 bg-gradient-to-b from-[#0a0e16] via-[#060810] to-[#03040a] border-r border-[rgba(201,162,39,.22)] shadow-[4px_0_32px_rgba(0,0,0,.55)] flex flex-col custom-scroll">
+       class="fixed top-18 left-0 bottom-0 w-70 z-40 bg-linear-to-b from-[#0a0e16] via-[#060810] to-[#03040a] border-r border-[rgba(201,162,39,.22)] shadow-[4px_0_32px_rgba(0,0,0,.55)] flex flex-col custom-scroll">
     
     <!-- Ember Effect -->
     <div class="absolute inset-0 pointer-events-none z-0 ember-bg"></div>
     
     <!-- Header -->
-    <div class="relative z-10 px-5 py-4 flex items-center justify-between min-h-[56px] flex-shrink-0 bg-gradient-to-b from-[rgba(201,162,39,.12)] to-[rgba(201,162,39,.04)] border-b-2 border-[rgba(201,162,39,.3)]">
+    <div class="relative z-10 px-5 py-4 flex items-center justify-between min-h-14 shrink-0 bg-linear-to-b from-[rgba(201,162,39,.12)] to-[rgba(201,162,39,.04)] border-b-2 border-[rgba(201,162,39,.3)]">
         <div class="text-gold-gradient text-[0.95rem] flex items-center gap-2">
             <span class="text-[#f2cf5b] text-xl drop-shadow-[0_0_8px_rgba(242,207,82,.5)]">⚔</span>
             <?php echo translate('admin_menu', 'Admin Panel'); ?>
@@ -246,7 +246,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
         <ul class="list-none p-0 m-0 flex flex-col gap-1">
             
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-[3px] border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'dashboard' || $active_page === 'dashboard') ? 'active-link' : ''; ?>" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-3 border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'dashboard' || $active_page === 'dashboard') ? 'active-link' : ''; ?>" 
                    href="<?php echo $base_path; ?>admin/dashboard">
                     <i class="fas fa-tachometer-alt w-5 text-center text-[0.9rem] group-hover:scale-110 group-hover:text-[#f2cf5b] transition-all duration-300"></i> 
                     <?php echo translate('admin_dashboard', 'Dashboard'); ?>
@@ -254,7 +254,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
             </li>
             
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-[3px] border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'users' || $active_page === 'users') ? 'active-link' : ''; ?>" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-3 border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'users' || $active_page === 'users') ? 'active-link' : ''; ?>" 
                    href="<?php echo $base_path; ?>admin/users">
                     <i class="fas fa-users w-5 text-center text-[0.9rem] group-hover:scale-110 group-hover:text-[#f2cf5b] transition-all duration-300"></i> 
                     <?php echo translate('admin_users', 'User Management'); ?>
@@ -262,7 +262,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
             </li>
             
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-[3px] border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'anews' || $active_page === 'anews') ? 'active-link' : ''; ?>" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-3 border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'anews' || $active_page === 'anews') ? 'active-link' : ''; ?>" 
                    href="<?php echo $base_path; ?>admin/anews">
                     <i class="fas fa-newspaper w-5 text-center text-[0.9rem] group-hover:scale-110 group-hover:text-[#f2cf5b] transition-all duration-300"></i> 
                     <?php echo translate('admin_news', 'News Management'); ?>
@@ -270,7 +270,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
             </li>
             
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-[3px] border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'characters' || $active_page === 'characters') ? 'active-link' : ''; ?>" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-3 border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'characters' || $active_page === 'characters') ? 'active-link' : ''; ?>" 
                    href="<?php echo $base_path; ?>admin/characters">
                     <i class="fas fa-user-edit w-5 text-center text-[0.9rem] group-hover:scale-110 group-hover:text-[#f2cf5b] transition-all duration-300"></i> 
                     <?php echo translate('admin_characters', 'Character Management'); ?>
@@ -278,7 +278,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
             </li>
             
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-[3px] border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'shop' || $active_page === 'shop') ? 'active-link' : ''; ?>" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-3 border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'shop' || $active_page === 'shop') ? 'active-link' : ''; ?>" 
                    href="<?php echo $base_path; ?>admin/ashop">
                     <i class="fas fa-shopping-cart w-5 text-center text-[0.9rem] group-hover:scale-110 group-hover:text-[#f2cf5b] transition-all duration-300"></i> 
                     <?php echo translate('admin_shop', 'Shop Management'); ?>
@@ -286,7 +286,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
             </li>
             
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-[3px] border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'gm_cmd' || $active_page === 'gm_cmd') ? 'active-link' : ''; ?>" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-3 border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'gm_cmd' || $active_page === 'gm_cmd') ? 'active-link' : ''; ?>" 
                    href="<?php echo $base_path; ?>admin/gm_cmd">
                     <i class="fas fa-terminal w-5 text-center text-[0.9rem] group-hover:scale-110 group-hover:text-[#f2cf5b] transition-all duration-300"></i> 
                     <?php echo translate('admin_gm_commands', 'GM Commands'); ?>
@@ -294,7 +294,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
             </li>
             
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-[3px] border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'settings' || $active_page === 'settings') ? 'active-link' : ''; ?>" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-gray-400 bg-black/20 border-l-3 border-transparent hover:text-gray-200 hover:bg-[rgba(201,162,39,.08)] hover:border-[rgba(201,162,39,.4)] hover:translate-x-1 transition-all duration-200 relative clip-gaming <?php echo ($page_class === 'settings' || $active_page === 'settings') ? 'active-link' : ''; ?>" 
                    href="<?php echo $base_path; ?>admin/settings/general">
                     <i class="fas fa-cogs w-5 text-center text-[0.9rem] group-hover:scale-110 group-hover:text-[#f2cf5b] transition-all duration-300"></i> 
                     <?php echo translate('admin_settings', 'Settings'); ?>
@@ -304,15 +304,15 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
             <!-- Divider -->
             <li class="my-3 px-2">
                 <div class="relative flex items-center">
-                    <div class="flex-grow border-t border-[rgba(201,162,39,.2)]"></div>
-                    <span class="flex-shrink-0 mx-3 text-[10px] text-[rgba(201,162,39,.6)]">◆</span>
-                    <div class="flex-grow border-t border-[rgba(201,162,39,.2)]"></div>
+                    <div class="grow border-t border-[rgba(201,162,39,.2)]"></div>
+                    <span class="shrink-0 mx-3 text-[10px] text-[rgba(201,162,39,.6)]">◆</span>
+                    <div class="grow border-t border-[rgba(201,162,39,.2)]"></div>
                 </div>
             </li>
 
             <!-- Logout -->
             <li>
-                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-red-400 bg-black/20 border-l-[3px] border-red-500/30 hover:text-red-300 hover:bg-red-500/10 hover:border-red-500 hover:translate-x-1 transition-all duration-200 relative clip-gaming" 
+                <a class="group flex items-center gap-3 px-3 py-2.5 text-[0.85rem] font-semibold tracking-wide text-red-400 bg-black/20 border-l-3 border-red-500/30 hover:text-red-300 hover:bg-red-500/10 hover:border-red-500 hover:translate-x-1 transition-all duration-200 relative clip-gaming" 
                    href="<?php echo $base_path; ?>logout">
                     <i class="fas fa-sign-out-alt w-5 text-center text-[0.9rem] group-hover:scale-110 transition-all duration-300"></i> 
                     <?php echo translate('logout', 'Logout'); ?>
@@ -323,7 +323,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
     </nav>
 
     <!-- Donation Button (above footer) - Reduced Size -->
-    <div class="relative z-10 donate-btn-wrapper flex-shrink-0">
+    <div class="relative z-10 donate-btn-wrapper shrink-0">
         <?php 
         $donate_image = __DIR__ . '/../img/support-button.png';
         if (file_exists($donate_image)): ?>
@@ -340,7 +340,7 @@ if (strpos($current_path, 'admin/dashboard') !== false) {
     </div>
 
     <!-- Footer -->
-    <div class="relative z-10 px-4 py-3 border-t border-[rgba(201,162,39,.1)] flex-shrink-0 text-center text-[0.65rem] text-gray-500 font-['Inter'] tracking-widest uppercase">
+    <div class="relative z-10 px-4 py-3 border-t border-[rgba(201,162,39,.1)] shrink-0 text-center text-[0.65rem] text-gray-500 font-['Inter'] tracking-widest uppercase">
         <span>© <?php echo date('Y'); ?> Sahtout WoW</span>
     </div>
 </aside>
@@ -368,14 +368,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 toggleIcon.className = 'fas fa-chevron-left text-xs transition-transform duration-300 group-hover:scale-125';
                 if (mainContent) {
                     mainContent.classList.remove('lg:ml-0');
-                    mainContent.classList.add('lg:ml-[280px]');
+                    mainContent.classList.add('lg:ml-70');
                 }
             } else {
                 sidebar.classList.add('sidebar-closed');
                 toggleBtn.style.left = '0px';
                 toggleIcon.className = 'fas fa-chevron-right text-xs transition-transform duration-300 group-hover:scale-125';
                 if (mainContent) {
-                    mainContent.classList.remove('lg:ml-[280px]');
+                    mainContent.classList.remove('lg:ml-70');
                     mainContent.classList.add('lg:ml-0');
                 }
             }
@@ -441,7 +441,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 sidebar.classList.add('sidebar-closed');
                 if (mainContent) {
-                    mainContent.classList.remove('lg:ml-[280px]');
+                    mainContent.classList.remove('lg:ml-70');
                     mainContent.classList.add('lg:ml-0');
                 }
             }

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -200,3 +200,6 @@ if (file_exists($project_root . 'includes/config.settings.php')) {
 
 <!-- Back to Top Script -->
 <script src="<?php echo $base_path; ?>assets/js/includes/footer.js"></script>
+
+</body>
+</html>

--- a/includes/header.php
+++ b/includes/header.php
@@ -30,6 +30,14 @@ if (!isset($_SESSION['user_id'])) {
 // Ensure $page_class is defined in the including page; default to 'default'
 $page_class = isset($page_class) ? $page_class : 'default';
 
+// Optional page-specific overrides set by the including page before this include:
+// $page_title, $page_meta_description, $page_meta_robots, $page_head (raw HTML for <head>), $page_body_class
+$page_title            = isset($page_title) ? $page_title : ($site_title_name ?? '');
+$page_meta_description = isset($page_meta_description) ? $page_meta_description : '';
+$page_meta_robots      = isset($page_meta_robots) ? $page_meta_robots : 'index';
+$page_head             = isset($page_head) ? $page_head : '';
+$page_body_class       = isset($page_body_class) ? $page_body_class : '';
+
 // Get current URL without query string
 $currentUrl = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 $currentUrl = rtrim($currentUrl, '/');
@@ -219,9 +227,13 @@ $is_auth_page = in_array($page_class, ['login', 'register']);
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <base href="<?php echo $base_path; ?>">
 
-    <?php if ($page_class === "how_to_play"): ?>
-        <title><?php echo $site_title_name . translate('how_to_play_title', 'How to Play'); ?></title>
+    <title><?php echo htmlspecialchars($page_title, ENT_QUOTES, 'UTF-8'); ?></title>
+
+    <?php if ($page_meta_description !== ''): ?>
+    <meta name="description" content="<?php echo htmlspecialchars($page_meta_description, ENT_QUOTES, 'UTF-8'); ?>">
     <?php endif; ?>
+
+    <meta name="robots" content="<?php echo htmlspecialchars($page_meta_robots, ENT_QUOTES, 'UTF-8'); ?>">
 
     <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;900&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -571,8 +583,10 @@ $is_auth_page = in_array($page_class, ['login', 'register']);
             display: block !important;
         }
     </style>
+
+    <?php echo $page_head; ?>
 </head>
-<body class="<?php echo htmlspecialchars($page_class, ENT_QUOTES, 'UTF-8'); ?>">
+<body class="<?php echo htmlspecialchars(trim($page_class . ' ' . $page_body_class), ENT_QUOTES, 'UTF-8'); ?>">
 
     <header class="main-header fixed top-0 left-0 right-0 <?php echo $is_auth_page ? 'transparent-header' : ''; ?>">
         <div class="header-inner max-w-[1600px] mx-auto px-4 md:px-8 py-3 flex items-center justify-between gap-4" style="position: relative;">
@@ -723,5 +737,3 @@ $is_auth_page = in_array($page_class, ['login', 'register']);
     </header>
 
     <script src="<?php echo $base_path; ?>assets/js/includes/header.js"></script>
-</body>
-</html>

--- a/includes/session.php
+++ b/includes/session.php
@@ -98,7 +98,7 @@ if (in_array($current_page, $protected_pages) || in_array($current_page, $admin_
 }
 
 // For login, register, and activate pages, redirect to account if already logged in
-$public_pages = ['login.php', 'register.php', 'activate.php','forgot-password.php', 'reset_password.php','resend-activation.php'];
+$public_pages = ['login.php', 'register.php', 'activate.php','forgot_password.php', 'reset_password.php','resend_activation.php'];
 if (in_array($current_page, $public_pages) && !empty($_SESSION['user_id']) && !empty($_SESSION['username'])) {
     /** @var \mysqli_stmt|false $stmt */
     $stmt = $auth_db->prepare("SELECT id FROM account WHERE id = ? AND username = ?");

--- a/index.php
+++ b/index.php
@@ -7,29 +7,13 @@ require_once $project_root . 'languages/language.php';
 require_once $project_root . 'includes/config.settings.php';
 
 $page_class = "home";
-$header_file = $project_root . 'includes/header.php';
+$page_title = $site_title_name . " " . translate('home_page_title', 'Home');
+$page_meta_description = translate('home_meta_description', 'Welcome to our World of Warcraft server. Join our Discord, YouTube, Instagram, create an account, or download the game now!');
+$page_meta_robots = 'index';
 
-if (file_exists($header_file)) {
-    include $header_file;
-} else {
-    die(translate('error_header_not_found', 'Error: Header file not found.'));
-}
-
-$query = "SELECT id, title, slug, image_url, post_date 
-          FROM server_news 
-          ORDER BY is_important DESC, post_date DESC 
-          LIMIT 4";
-$result = $site_db->query($query);
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('home_meta_description', 'Welcome to our World of Warcraft server. Join our Discord, YouTube, Instagram, create an account, or download the game now!'); ?>">
-    <meta name="robots" content="index">
-    <title><?php echo $site_title_name . " " . translate('home_page_title', 'Home'); ?></title>
-    <style>
+<style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap');
 
         * { font-family: 'Inter', sans-serif; }
@@ -319,8 +303,22 @@ $result = $site_db->query($query);
             'description' => $youtube_description ?? 'Lichking Trailer, Replace it with your own ....',
         ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
     </script>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+$header_file = $project_root . 'includes/header.php';
+if (file_exists($header_file)) {
+    include $header_file;
+} else {
+    die(translate('error_header_not_found', 'Error: Header file not found.'));
+}
+
+$query = "SELECT id, title, slug, image_url, post_date 
+          FROM server_news 
+          ORDER BY is_important DESC, post_date DESC 
+          LIMIT 4";
+$result = $site_db->query($query);
+?>
 
     <main class="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-10">
 
@@ -550,15 +548,6 @@ $result = $site_db->query($query);
         </div>
     </main>
 
-    <?php
-    $footer_file = $project_root . 'includes/footer.php';
-    if (file_exists($footer_file)) {
-        include $footer_file;
-    } else {
-        die(translate('error_footer_not_found', 'Error: Footer file not found.'));
-    }
-    ?>
-
     <script>
         const track = document.getElementById('sliderTrack');
         const slides = track.querySelectorAll('.slide');
@@ -618,8 +607,15 @@ $result = $site_db->query($query);
         });
     </script>
     <script src="<?php echo $base_path; ?>assets/js/home.js"></script>
-</body>
-</html>
+
+    <?php
+    $footer_file = $project_root . 'includes/footer.php';
+    if (file_exists($footer_file)) {
+        include $footer_file;
+    } else {
+        die(translate('error_footer_not_found', 'Error: Footer file not found.'));
+    }
+    ?>
 <?php
 if (isset($site_db)) {
     $site_db->close();

--- a/index.php
+++ b/index.php
@@ -292,6 +292,7 @@ ob_start();
         .line-clamp-2 {
             display: -webkit-box;
             -webkit-line-clamp: 2;
+            line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
         }
@@ -320,7 +321,7 @@ $query = "SELECT id, title, slug, image_url, post_date
 $result = $site_db->query($query);
 ?>
 
-    <main class="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-10">
+    <main class="max-w-350 mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-10">
 
         <!-- Responsive grid: stacks on mobile, side-by-side on large screens -->
         <div class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_380px] gap-6 md:gap-8">
@@ -447,7 +448,7 @@ $result = $site_db->query($query);
                                              class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300">
                                         <div class="absolute inset-0" style="background:linear-gradient(to top, rgba(0,0,0,.9), transparent 60%);"></div>
                                         <div class="absolute bottom-0 left-0 right-0 p-2 sm:p-3 min-w-0">
-                                            <h3 class="text-xs sm:text-sm font-bold text-white min-w-0 break-words [overflow-wrap:anywhere] line-clamp-2"><?php echo htmlspecialchars($news['title']); ?></h3>
+                                            <h3 class="text-xs sm:text-sm font-bold text-white min-w-0 wrap-anywhere line-clamp-2"><?php echo htmlspecialchars($news['title']); ?></h3>
                                         </div>
                                     </div>
                                     <div class="p-2 sm:p-3">

--- a/pages/account.php
+++ b/pages/account.php
@@ -941,7 +941,7 @@ include_once $project_root . 'includes/header.php';
                                         <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
                                         <input type="hidden" name="guid" value="<?php echo $char['guid']; ?>">
                                         <div class="flex flex-wrap gap-2">
-                                            <select class="flex-1 min-w-[100px] px-3 py-1.5 bg-[rgba(0,0,0,0.4)] border border-[rgba(201,162,39,0.2)] text-gray-200 text-sm focus:border-[#f2cf5b] focus:outline-none" name="destination" required>
+                                            <select class="flex-1 min-w-25 px-3 py-1.5 bg-[rgba(0,0,0,0.4)] border border-[rgba(201,162,39,0.2)] text-gray-200 text-sm focus:border-[#f2cf5b] focus:outline-none" name="destination" required>
                                                 <option value=""><?php echo translate('select_city_placeholder', 'Select city'); ?></option>
                                                 <option value="shattrath"><?php echo translate('city_shattrath', 'Shattrath'); ?></option>
                                                 <option value="dalaran"><?php echo translate('city_dalaran', 'Dalaran'); ?></option>

--- a/pages/account.php
+++ b/pages/account.php
@@ -6,6 +6,7 @@ require_once $project_root . 'includes/session.php';
 require_once $project_root . 'includes/srp6.php';
 require_once $project_root . 'includes/config.mail.php';
 require_once $project_root . 'languages/language.php'; // Include language file for translations
+require_once $project_root . 'includes/config.settings.php';
 
 // Early session validation
 if (!isset($_SESSION['user_id']) || !isset($_SESSION['username'])) {
@@ -414,10 +415,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-// Now proceed with page rendering
-$page_class = 'account';
-include_once $project_root . 'includes/header.php';
-
 // Database queries for page content
 if ($auth_db->connect_error || $char_db->connect_error || $site_db->connect_error) {
     $error = translate('error_database_connection', 'Database connection failed');
@@ -576,19 +573,13 @@ function getFactionIcon($race) {
 function getAvatarDisplayName($filename) {
     return translate('avatar_' . str_replace('.', '_', $filename), $filename);
 }
+
+// Now proceed with page rendering
+$page_class = 'account';
+$page_title = $site_title_name . ' ' . sprintf(translate('page_title', 'Account - %s'), htmlspecialchars($accountInfo['username'] ?? ''));
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo $site_title_name ." ". sprintf(translate('page_title', 'Account - %s'), htmlspecialchars($accountInfo['username'] ?? '')); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
     <style>
         /* Page background - Show full background image without overlay */
         body {
@@ -727,8 +718,11 @@ function getAvatarDisplayName($filename) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+include_once $project_root . 'includes/header.php';
+?>
 
 <div class="account-content min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
@@ -1111,8 +1105,6 @@ function getAvatarDisplayName($filename) {
     </div>
 </div>
 
-<?php include_once $project_root . 'includes/footer.php'; ?>
-
 <!-- JavaScript for Tabs and Avatar Selection -->
 <script>
     // Tab switching functionality
@@ -1196,8 +1188,8 @@ function getAvatarDisplayName($filename) {
         }
     });
 </script>
-</body>
-</html>
+
+<?php include_once $project_root . 'includes/footer.php'; ?>
 <?php
 ob_end_flush(); // Flush the output buffer
 ?>

--- a/pages/activate.php
+++ b/pages/activate.php
@@ -193,24 +193,12 @@ if (!$token) {
     }
 }
 
-// Include header.php after logic to avoid headers-already-sent error
-require_once $project_root . 'includes/header.php';
-?>
+$page_title = $site_title_name ." ". translate('page_title', '- Activate Account');
+$page_meta_description = translate('meta_description', 'Activate your account to join our World of Warcraft server adventure!');
+$page_meta_robots = 'index';
 
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('meta_description', 'Activate your account to join our World of Warcraft server adventure!'); ?>">
-    <meta name="robots" content="index">
-    <title><?php echo $site_title_name ." ". translate('page_title', '- Activate Account'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
+ob_start();
+?>
     <style>
         /* Page background */
         body {
@@ -329,8 +317,12 @@ require_once $project_root . 'includes/header.php';
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+// Include header.php after logic to avoid headers-already-sent error
+require_once $project_root . 'includes/header.php';
+?>
 <div class="activate-content min-h-screen flex items-center justify-center px-4 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4 flex items-center justify-center">
         
@@ -388,5 +380,3 @@ require_once $project_root . 'includes/header.php';
 </div>
 
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/admin/anews.php
+++ b/pages/admin/anews.php
@@ -218,20 +218,15 @@ $stmt->bind_param("ii", $items_per_page, $offset);
 $stmt->execute();
 $news_result = $stmt->get_result();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('admin_news_meta_description', 'News Management for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('admin_news_page_title', 'News Management'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
-    <style>
+<?php
+$page_title = translate('admin_news_page_title', 'News Management');
+$page_meta_description = translate('admin_news_meta_description', 'News Management for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'news';
+
+ob_start();
+?>
+<style>
         * { font-family: 'Inter', sans-serif; }
 
         body {
@@ -569,9 +564,9 @@ $news_result = $stmt->get_result();
             }
         }
     </style>
-</head>
-<body class="news">
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php $page_head = ob_get_clean(); ?>
+
+<?php include $project_root . 'includes/header.php'; ?>
 
     <!-- Main Content Area with Sidebar -->
     <div class="flex relative min-h-screen">

--- a/pages/admin/ashop.php
+++ b/pages/admin/ashop.php
@@ -418,20 +418,15 @@ try {
     if (isset($stmt)) $stmt->close();
 }
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('admin_shop_meta_description', 'Shop Management for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('admin_shop_page_title', 'Shop Management'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    
-    <style>
+<?php
+$page_title = translate('admin_shop_page_title', 'Shop Management');
+$page_meta_description = translate('admin_shop_meta_description', 'Shop Management for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'shop';
+
+ob_start();
+?>
+<style>
         * { font-family: 'Inter', sans-serif; }
 
         body {
@@ -776,9 +771,9 @@ try {
             }
         }
     </style>
-</head>
-<body class="shop">
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php $page_head = ob_get_clean(); ?>
+
+<?php include $project_root . 'includes/header.php'; ?>
 
     <!-- Main Content Area with Sidebar -->
     <div class="flex relative min-h-screen">
@@ -1407,6 +1402,6 @@ try {
             }
         });
     </script>
+<?php $site_db->close(); ?>
 </body>
 </html>
-<?php $site_db->close(); ?>

--- a/pages/admin/characters.php
+++ b/pages/admin/characters.php
@@ -307,20 +307,14 @@ if (empty($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('admin_chars_meta_description', 'Character Management for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('admin_chars_page_title', 'Character Management'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
-    <style>
+<?php
+$page_title = translate('admin_chars_page_title', 'Character Management');
+$page_meta_description = translate('admin_chars_meta_description', 'Character Management for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+
+ob_start();
+?>
+<style>
         * { font-family: 'Inter', sans-serif; }
 
         body {
@@ -544,9 +538,9 @@ if (empty($_SESSION['csrf_token'])) {
             }
         }
     </style>
-</head>
-<body>
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php $page_head = ob_get_clean(); ?>
+
+<?php include $project_root . 'includes/header.php'; ?>
 
     <!-- Main Content Area with Sidebar -->
     <div class="flex relative min-h-screen">
@@ -850,10 +844,10 @@ if (empty($_SESSION['csrf_token'])) {
             }
         });
     </script>
-</body>
-</html>
-<?php 
+<?php
 $site_db->close();
 $auth_db->close();
 $char_db->close();
 ?>
+</body>
+</html>

--- a/pages/admin/characters.php
+++ b/pages/admin/characters.php
@@ -549,7 +549,7 @@ ob_start();
         <?php include $project_root . 'includes/admin_sidebar.php'; ?>
         
         <!-- Main Content -->
-        <main class="main-content-area flex-1 p-3 sm:p-4 md:p-6 lg:p-8 transition-all duration-300 lg:ml-[280px]">
+        <main class="main-content-area flex-1 p-3 sm:p-4 md:p-6 lg:p-8 transition-all duration-300 lg:ml-70">
             <div class="content-wrapper">
                 <div class="space-y-4 md:space-y-6 lg:space-y-8">
                     

--- a/pages/admin/dashboard.php
+++ b/pages/admin/dashboard.php
@@ -140,20 +140,14 @@ $bans_query = "SELECT ab.id, ab.bandate, ab.unbandate, ab.banreason, a.username
                LIMIT 5";
 $bans_result = $auth_db->query($bans_query);
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('admin_dashboard_meta_description', 'Admin and Moderator Dashboard for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('admin_dashboard_page_title', 'Admin & Moderator Dashboard'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
-    <style>
+<?php
+$page_title = translate('admin_dashboard_page_title', 'Admin & Moderator Dashboard');
+$page_meta_description = translate('admin_dashboard_meta_description', 'Admin and Moderator Dashboard for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+
+ob_start();
+?>
+<style>
         * { font-family: 'Inter', sans-serif; }
 
         body {
@@ -451,9 +445,9 @@ $bans_result = $auth_db->query($bans_query);
             }
         }
     </style>
-</head>
-<body>
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php $page_head = ob_get_clean(); ?>
+
+<?php include $project_root . 'includes/header.php'; ?>
 
     <!-- Main Content Area with Sidebar -->
     <div class="flex relative min-h-screen">

--- a/pages/admin/dashboard.php
+++ b/pages/admin/dashboard.php
@@ -456,7 +456,7 @@ ob_start();
         <?php include $project_root . 'includes/admin_sidebar.php'; ?>
         
         <!-- Main Content -->
-        <main class="main-content-area flex-1 p-3 sm:p-4 md:p-6 lg:p-8 transition-all duration-300 lg:ml-[280px]">
+        <main class="main-content-area flex-1 p-3 sm:p-4 md:p-6 lg:p-8 transition-all duration-300 lg:ml-70">
             <div class="content-wrapper">
                 <div class="space-y-4 md:space-y-6 lg:space-y-8">
                     

--- a/pages/admin/gm_cmd.php
+++ b/pages/admin/gm_cmd.php
@@ -60,20 +60,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_soap', 'Execute SOAP GM commands for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('page_title_soap', 'SOAP Command Executor'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
-    <style>
+<?php
+$page_title = translate('page_title_soap', 'SOAP Command Executor');
+$page_meta_description = translate('page_description_soap', 'Execute SOAP GM commands for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+
+ob_start();
+?>
+<style>
         * { font-family: 'Inter', sans-serif; }
 
         body {
@@ -271,9 +265,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     </style>
-</head>
-<body>
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php $page_head = ob_get_clean(); ?>
+
+<?php include $project_root . 'includes/header.php'; ?>
 
     <!-- Main Content Area with Sidebar -->
     <div class="flex relative min-h-screen">

--- a/pages/admin/settings/general.php
+++ b/pages/admin/settings/general.php
@@ -83,12 +83,12 @@ include $project_root . 'includes/header.php';
         <?php include $project_root . 'includes/admin_sidebar.php'; ?>
         
         <!-- Main Content -->
-        <main class="main-content-area flex-1 p-3 sm:p-4 md:p-6 lg:p-8 transition-all duration-300 lg:ml-[280px]">
-            <div class="max-w-[1400px] mx-auto px-1 sm:px-4 md:px-6 lg:px-8 xl:px-10">
+        <main class="main-content-area flex-1 p-3 sm:p-4 md:p-6 lg:p-8 transition-all duration-300 lg:ml-70">
+            <div class="max-w-350 mx-auto px-1 sm:px-4 md:px-6 lg:px-8 xl:px-10">
                 <div class="space-y-4 md:space-y-6 lg:space-y-8">
                     
                     <h1 class="wow-title text-2xl md:text-3xl lg:text-4xl font-black 
-                               bg-gradient-to-b from-[#fff7d6] via-[#f2cf5b] via-[#c9a227] to-[#8a6a14] 
+                               bg-[linear-gradient(180deg,#fff7d6_0%,#f2cf5b_35%,#c9a227_62%,#8a6a14_100%)]
                                bg-clip-text text-transparent drop-shadow-[0_3px_6px_rgba(0,0,0,.85)]">
                         <?php echo translate('page_title_general', 'General Settings'); ?>
                     </h1>
@@ -98,13 +98,13 @@ include $project_root . 'includes/header.php';
 
                     <!-- Success / Error Messages -->
                     <?php if (isset($_GET['status']) && $_GET['status'] === 'success'): ?>
-                        <div class="bg-[#2ecc71]/15 border border-[#2ecc71]/40 text-[#2ecc71] 
+                        <div class="bg-wow-success/15 border border-wow-success/40 text-wow-success 
                                     p-4 rounded-sm flex items-center gap-3">
                             <i class="fas fa-check-circle text-xl"></i>
                             <span><?php echo translate('msg_settings_saved', 'Settings updated successfully!'); ?></span>
                         </div>
                     <?php elseif (isset($_GET['status']) && $_GET['status'] === 'error'): ?>
-                        <div class="bg-[#e74c3c]/15 border border-[#e74c3c]/40 text-[#e74c3c] 
+                        <div class="bg-wow-error/15 border border-wow-error/40 text-wow-error 
                                     p-4 rounded-sm flex items-center gap-3">
                             <i class="fas fa-exclamation-circle text-xl"></i>
                             <div>
@@ -115,8 +115,8 @@ include $project_root . 'includes/header.php';
                     <?php endif; ?>
 
                     <!-- General Settings Form -->
-                    <div class="relative bg-gradient-to-b from-[#161920]/92 to-[#080a0e]/90 
-                                border border-[#c9a227]/[0.22] 
+                    <div class="relative bg-linear-to-b from-[#161920]/92 to-[#080a0e]/90 
+                                border border-[#c9a227]/22 
                                 shadow-[0_12px_32px_rgba(0,0,0,.55),inset_0_0_60px_rgba(0,0,0,.45)]
                                 p-4 md:p-6 lg:p-8 panel-gold-corners">
                         
@@ -216,7 +216,7 @@ include $project_root . 'includes/header.php';
                                                  bg-[#0a0e16]/80 border border-[#c9a227]/30 rounded-sm 
                                                  focus:border-[#f2cf5b] focus:shadow-[0_0_10px_rgba(242,207,82,.2)] 
                                                  focus:bg-[#0f141e]/90 outline-none transition-all duration-200 
-                                                 placeholder:text-[#96aac8]/40 resize-y min-h-[80px]"
+                                                 placeholder:text-[#96aac8]/40 resize-y min-h-20"
                                           rows="3"
                                           maxlength="500"
                                           placeholder="<?php echo translate('placeholder_youtube_description', 'Watch a featured video here...'); ?>"><?php echo htmlspecialchars($youtube_description ?? 'Watch a featured video here. Replace it with your own channel or highlight later.'); ?></textarea>
@@ -233,11 +233,11 @@ include $project_root . 'includes/header.php';
                                 </label>
                                 
                                 <!-- Current Logo Preview - Centered -->
-                                <div class="flex justify-center items-center p-2 min-h-[140px] 
+                                <div class="flex justify-center items-center p-2 min-h-35 
                                             bg-[#0a0e16]/50 border border-[#c9a227]/20 rounded-sm mb-3">
                                     <img src="<?php echo $base_path . htmlspecialchars($site_logo); ?>" 
                                          alt="Current Logo" 
-                                         class="max-h-[120px] max-w-full object-contain">
+                                         class="max-h-30 max-w-full object-contain">
                                 </div>
                                 
                                 <!-- Upload Area - Centered -->
@@ -282,7 +282,7 @@ include $project_root . 'includes/header.php';
 
                                 foreach ($icons as $platform => $icon): ?>
                                     <div class="flex items-stretch mb-2">
-                                        <span class="flex items-center justify-center px-4 py-3 min-w-[48px] 
+                                        <span class="flex items-center justify-center px-4 py-3 min-w-12 
                                                      bg-[#0a0e16]/90 border border-[#c9a227]/30 border-r-0 
                                                      text-[#f2cf5b] rounded-l-sm text-base">
                                           
@@ -309,7 +309,7 @@ include $project_root . 'includes/header.php';
                             <div class="pt-4 border-t border-[rgba(201,162,39,.1)] flex justify-end">
                                 <button type="submit" class="btn-clip inline-flex items-center gap-2 px-6 py-3 
                                                              font-extrabold text-xs uppercase tracking-wider
-                                                             bg-gradient-to-b from-[#f6d478] via-[#c9a227] to-[#8a6a14] 
+                                                             bg-linear-to-b from-[#f6d478] via-[#c9a227] to-[#8a6a14] 
                                                              text-[#1a1200] shadow-[inset_0_0_0_1px_rgba(255,255,255,.28),inset_0_-8px_14px_rgba(0,0,0,.25)]
                                                              hover:scale-105 transition-transform duration-200">
                                     <i class="fas fa-save"></i>

--- a/pages/admin/settings/general.php
+++ b/pages/admin/settings/general.php
@@ -11,23 +11,24 @@ if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin', 'mode
 }
 
 $page_class = 'general';
+$page_title = translate('page_title_general', 'General Settings');
+$page_meta_description = translate('page_description_general', 'General Settings for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed';
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_general', 'General Settings for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('page_title_general', 'General Settings'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Only keep what Tailwind CANNOT do */
-        
+
+        /* Page background (was inline on <body>) */
+        body {
+            background-image:
+                radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
+                radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
+                linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);
+        }
+
         /* Font families - Tailwind can't handle font-family well inline */
         * { font-family: 'Inter', sans-serif; }
         .wow-title, .section-title, .form-label { font-family: 'Cinzel', serif; }
@@ -69,14 +70,11 @@ $page_class = 'general';
             clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
         }
     </style>
-</head>
-<body class="min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed"
-      style="background-image: 
-        radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
-        radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
-        linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);">
-    
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+?>
 
     <!-- Main Content Area with Sidebar -->
     <div class="flex relative min-h-screen">

--- a/pages/admin/settings/page_manager.php
+++ b/pages/admin/settings/page_manager.php
@@ -11,20 +11,12 @@ if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin', 'mode
 }
 
 $page_class = 'page_manager';
+$page_title = translate('title_page_manager', 'Page Manager');
+$page_meta_description = translate('page_description_page_manager', 'Page Manager for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_page_manager', 'Page Manager for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('title_page_manager', 'Page Manager'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Only custom CSS for things Tailwind can't do */
         body {
@@ -113,9 +105,11 @@ $page_class = 'page_manager';
             filter: drop-shadow(0 3px 6px rgba(0,0,0,.85));
         }
     </style>
-</head>
-<body>
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+?>
 
     <div class="flex relative min-h-screen">
         

--- a/pages/admin/settings/realm.php
+++ b/pages/admin/settings/realm.php
@@ -11,6 +11,10 @@ if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin', 'mode
 }
 
 $page_class = 'realm';
+$page_title = translate('page_title_realm', 'Realm Configuration');
+$page_meta_description = translate('page_description_realm', 'Realm Configuration for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed';
 
 $errors = [];
 $success = false;
@@ -100,23 +104,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_realm', 'Realm Configuration for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('page_title_realm', 'Realm Configuration'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Only keep what Tailwind CANNOT do */
-        
+
+        /* Page background (was inline on <body>) */
+        body {
+            background-image:
+                radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
+                radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
+                linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);
+        }
+
         /* Font families */
         * { font-family: 'Inter', sans-serif; }
         .wow-title, .section-title, .form-label { font-family: 'Cinzel', serif; }
@@ -158,14 +158,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             clip-path: polygon(10px 0, 100% 0, 100% calc(100% - 10px), calc(100% - 10px) 100%, 0 100%, 0 10px);
         }
     </style>
-</head>
-<body class="min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed"
-      style="background-image: 
-        radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
-        radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
-        linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);">
-    
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+?>
 
     <div class="flex relative min-h-screen">
         

--- a/pages/admin/settings/recaptcha.php
+++ b/pages/admin/settings/recaptcha.php
@@ -11,6 +11,10 @@ if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin', 'mode
 }
 
 $page_class = 'recaptcha';
+$page_title = translate('page_title_recaptcha', 'reCAPTCHA Settings');
+$page_meta_description = translate('page_description_recaptcha', 'reCAPTCHA Settings for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed';
 
 $errors = [];
 $success = false;
@@ -79,23 +83,19 @@ define('RECAPTCHA_SECRET_KEY', \$recaptcha_secret_key);
         }
     }
 }
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_recaptcha', 'reCAPTCHA Settings for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('page_title_recaptcha', 'reCAPTCHA Settings'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Only keep what Tailwind CANNOT do */
-        
+
+        /* Page background (was inline on <body>) */
+        body {
+            background-image:
+                radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
+                radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
+                linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);
+        }
+
         /* Font families */
         * { font-family: 'Inter', sans-serif; }
         .wow-title, .section-title, .form-label { font-family: 'Cinzel', serif; }
@@ -203,14 +203,11 @@ define('RECAPTCHA_SECRET_KEY', \$recaptcha_secret_key);
             color: #e74c3c;
         }
     </style>
-</head>
-<body class="min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed"
-      style="background-image: 
-        radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
-        radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
-        linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);">
-    
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+?>
 
     <div class="flex relative min-h-screen">
         

--- a/pages/admin/settings/smtp.php
+++ b/pages/admin/settings/smtp.php
@@ -11,6 +11,10 @@ if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin', 'mode
 }
 
 $page_class = 'smtp';
+$page_title = translate('page_title_smtp', 'SMTP Settings');
+$page_meta_description = translate('page_description_smtp', 'SMTP Settings for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed';
 
 $errors = [];
 $success = false;
@@ -204,23 +208,19 @@ function getMailer(): PHPMailer {
         }
     }
 }
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_smtp', 'SMTP Settings for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('page_title_smtp', 'SMTP Settings'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Only keep what Tailwind CANNOT do */
-        
+
+        /* Page background (was inline on <body>) */
+        body {
+            background-image:
+                radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
+                radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
+                linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);
+        }
+
         /* Font families */
         * { font-family: 'Inter', sans-serif; }
         .wow-title, .section-title, .form-label { font-family: 'Cinzel', serif; }
@@ -328,14 +328,11 @@ function getMailer(): PHPMailer {
             color: #e74c3c;
         }
     </style>
-</head>
-<body class="min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed"
-      style="background-image: 
-        radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
-        radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
-        linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);">
-    
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+?>
 
     <div class="flex relative min-h-screen">
         

--- a/pages/admin/settings/soap.php
+++ b/pages/admin/settings/soap.php
@@ -11,6 +11,10 @@ if (!isset($_SESSION['user_id']) || !in_array($_SESSION['role'], ['admin', 'mode
 }
 
 $page_class = 'soap';
+$page_title = translate('title_soap_settings', 'SOAP Settings');
+$page_meta_description = translate('page_description_soap', 'SOAP Settings for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed';
 
 $errors = [];
 $success = false;
@@ -104,23 +108,19 @@ if (!defined('ALLOWED_ACCESS')) {
         }
     }
 }
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_soap', 'SOAP Settings for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('title_soap_settings', 'SOAP Settings'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Only keep what Tailwind CANNOT do */
-        
+
+        /* Page background (was inline on <body>) */
+        body {
+            background-image:
+                radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
+                radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
+                linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);
+        }
+
         /* Font families */
         * { font-family: 'Inter', sans-serif; }
         .wow-title, .section-title, .form-label { font-family: 'Cinzel', serif; }
@@ -191,14 +191,11 @@ if (!defined('ALLOWED_ACCESS')) {
             transform: rotate(180deg);
         }
     </style>
-</head>
-<body class="min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed"
-      style="background-image: 
-        radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
-        radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
-        linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);">
-    
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+?>
 
     <div class="flex relative min-h-screen">
         

--- a/pages/admin/settings/vote_sites.php
+++ b/pages/admin/settings/vote_sites.php
@@ -365,23 +365,24 @@ try {
 }
 
 $page_class = 'vote-sites';
+$page_title = translate('page_title_manage_vote_sites', 'Manage Vote Sites');
+$page_meta_description = translate('page_description_vote_sites', 'Vote Sites Management for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+$page_body_class = 'min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed';
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('page_description_vote_sites', 'Vote Sites Management for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('page_title_manage_vote_sites', 'Manage Vote Sites'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Only keep what Tailwind CANNOT do */
-        
+
+        /* Page background (was inline on <body>) */
+        body {
+            background-image:
+                radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
+                radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
+                linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);
+        }
+
         /* Font families */
         * { font-family: 'Inter', sans-serif; }
         .wow-title, .section-title, .form-label, .table-wow th { font-family: 'Cinzel', serif; }
@@ -489,14 +490,11 @@ $page_class = 'vote-sites';
             border: 0;
         }
     </style>
-</head>
-<body class="min-h-screen text-[#d8d8d8] bg-[#05070b] bg-fixed"
-      style="background-image: 
-        radial-gradient(1000px 700px at -10% 35%, rgba(59,130,246,.14), transparent 65%),
-        radial-gradient(800px 600px at -5% 85%, rgba(124,58,237,.10), transparent 70%),
-        linear-gradient(180deg, #0a0e16 0%, #060810 45%, #03040a 100%);">
-    
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+?>
 
     <div class="flex relative min-h-screen">
         

--- a/pages/admin/users.php
+++ b/pages/admin/users.php
@@ -364,20 +364,14 @@ function getGMLevel($gmlevel) {
     return '<span class="text-cyan-400 font-semibold">' . translate('admin_users_gmlevel_prefix', 'GM Level') . ' ' . $gmlevel . '</span>';
 }
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('admin_users_meta_description', 'User Management for Sahtout WoW Server'); ?>">
-    <meta name="robots" content="noindex">
-    <title><?php echo translate('admin_users_page_title', 'User Management'); ?></title>
-    <link rel="icon" href="<?php echo $base_path . $site_logo; ?>" type="image/x-icon">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
-    <style>
+<?php
+$page_title = translate('admin_users_page_title', 'User Management');
+$page_meta_description = translate('admin_users_meta_description', 'User Management for Sahtout WoW Server');
+$page_meta_robots = 'noindex';
+
+ob_start();
+?>
+<style>
         * { font-family: 'Inter', sans-serif; }
 
         body {
@@ -649,9 +643,9 @@ function getGMLevel($gmlevel) {
             }
         }
     </style>
-</head>
-<body>
-    <?php include $project_root . 'includes/header.php'; ?>
+<?php $page_head = ob_get_clean(); ?>
+
+<?php include $project_root . 'includes/header.php'; ?>
 
     <!-- Main Content Area with Sidebar -->
     <div class="flex relative min-h-screen">
@@ -1122,10 +1116,10 @@ function getGMLevel($gmlevel) {
             }
         });
     </script>
-</body>
-</html>
 <?php
 $site_db->close();
 $auth_db->close();
 $char_db->close();
 ?>
+</body>
+</html>

--- a/pages/armory/arena_2v2.php
+++ b/pages/armory/arena_2v2.php
@@ -6,7 +6,6 @@ require_once __DIR__ . '/../../includes/paths.php';
 
 // Use $project_root for filesystem includes
 require_once $project_root . 'includes/session.php';
-require_once $project_root . 'includes/header.php';
 
 // Faction from race
 function getFaction($race) {
@@ -96,19 +95,18 @@ $teams = [];
 while ($row = $result->fetch_assoc()) {
     $teams[] = $row;
 }
-?>
 
-<!DOCTYPE html>
-<html lang="<?php echo $_SESSION['lang'] ?? 'en'; ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo $site_title_name . " " . translate('arena_2v2_page_title', 'Top 50 2v2 Arena Teams'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <!-- Font Awesome for icons -->
-    
-    <style>
+// Ensure site settings and translations are loaded for page head config
+require_once $project_root . 'includes/config.settings.php';
+require_once $project_root . 'languages/language.php';
+
+// Page configuration
+$page_title = $site_title_name . " " . translate('arena_2v2_page_title', 'Top 50 2v2 Arena Teams');
+$page_class = 'armory';
+
+ob_start();
+?>
+<style>
         /* Page background - Show full background image without overlay */
         body {
             background: url('<?php echo $base_path; ?>img/backgrounds/bg-armory.jpg') no-repeat center center fixed;
@@ -395,8 +393,11 @@ while ($row = $result->fetch_assoc()) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+require_once $project_root . 'includes/header.php';
+?>
 <div class="arena-content min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
         <!-- Main Container - Darker Glass Effect -->
@@ -523,5 +524,3 @@ while ($row = $result->fetch_assoc()) {
 </div>
 
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/armory/arena_3v3.php
+++ b/pages/armory/arena_3v3.php
@@ -6,7 +6,6 @@ require_once __DIR__ . '/../../includes/paths.php';
 
 // Use $project_root for filesystem includes
 require_once $project_root . 'includes/session.php';
-require_once $project_root . 'includes/header.php';
 
 // Faction from race
 function getFaction($race) {
@@ -99,19 +98,18 @@ if ($result) {
         $teams[] = $row;
     }
 }
-?>
 
-<!DOCTYPE html>
-<html lang="<?php echo $_SESSION['lang'] ?? 'en'; ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo $site_title_name . " " . translate('arena_3v3_page_title', 'Top 50 3v3 Arena Teams'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <!-- Font Awesome for icons -->
-    
-    <style>
+// Ensure site settings and translations are loaded for page head config
+require_once $project_root . 'includes/config.settings.php';
+require_once $project_root . 'languages/language.php';
+
+// Page configuration
+$page_title = $site_title_name . " " . translate('arena_3v3_page_title', 'Top 50 3v3 Arena Teams');
+$page_class = 'armory';
+
+ob_start();
+?>
+<style>
         /* Page background - Show full background image without overlay */
         body {
             background: url('<?php echo $base_path; ?>img/backgrounds/bg-armory.jpg') no-repeat center center fixed;
@@ -398,8 +396,11 @@ if ($result) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+require_once $project_root . 'includes/header.php';
+?>
 <div class="arena-content min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
         <!-- Main Container - Darker Glass Effect -->
@@ -526,5 +527,3 @@ if ($result) {
 </div>
 
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/armory/arena_5v5.php
+++ b/pages/armory/arena_5v5.php
@@ -6,7 +6,6 @@ require_once __DIR__ . '/../../includes/paths.php';
 
 // Use $project_root for filesystem includes
 require_once $project_root . 'includes/session.php';
-require_once $project_root . 'includes/header.php';
 
 // Faction from race
 function getFaction($race) {
@@ -99,19 +98,18 @@ if ($result) {
         $teams[] = $row;
     }
 }
-?>
 
-<!DOCTYPE html>
-<html lang="<?php echo $_SESSION['lang'] ?? 'en'; ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo $site_title_name . " " . translate('arena_5v5_page_title', 'Top 50 5v5 Arena Teams'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <!-- Font Awesome for icons -->
-    
-    <style>
+// Ensure site settings and translations are loaded for page head config
+require_once $project_root . 'includes/config.settings.php';
+require_once $project_root . 'languages/language.php';
+
+// Page configuration
+$page_title = $site_title_name . " " . translate('arena_5v5_page_title', 'Top 50 5v5 Arena Teams');
+$page_class = 'armory';
+
+ob_start();
+?>
+<style>
         /* Page background - Show full background image without overlay */
         body {
             background: url('<?php echo $base_path; ?>img/backgrounds/bg-armory.jpg') no-repeat center center fixed;
@@ -398,8 +396,11 @@ if ($result) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+require_once $project_root . 'includes/header.php';
+?>
 <div class="arena-content min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
         <!-- Main Container - Darker Glass Effect -->
@@ -526,5 +527,3 @@ if ($result) {
 </div>
 
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/armory/arenateam.php
+++ b/pages/armory/arenateam.php
@@ -133,13 +133,11 @@ if ($team) {
     }
 }
 
-// Render global website header
-require_once $project_root . 'includes/header.php';
+// Page configuration
+$page_class = 'armory';
+
+ob_start();
 ?>
-
-<!-- Tailwind CSS -->
-<!-- Font Awesome for icons -->
-
 <style>
     /* Page background - Show full background image without overlay */
     body {
@@ -282,6 +280,12 @@ require_once $project_root . 'includes/header.php';
         }
     }
 </style>
+<?php
+$page_head = ob_get_clean();
+
+// Render global website header
+require_once $project_root . 'includes/header.php';
+?>
 
 <div class="arena-content min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">

--- a/pages/armory/solo_pvp.php
+++ b/pages/armory/solo_pvp.php
@@ -5,7 +5,6 @@ require_once __DIR__ . '/../../includes/paths.php';
 
 // Use $project_root for filesystem includes
 require_once $project_root . 'includes/session.php';
-require_once $project_root . 'includes/header.php';
 
 $search = '';
 $search_error = '';
@@ -107,19 +106,18 @@ function classIcon($class) {
     $className = isset($classMap[$class]) ? $classMap[$class] : 'unknown';
     return $base_path . "img/accountimg/class/{$className}.webp";
 }
-?>
 
-<!DOCTYPE html>
-<html lang="<?php echo $_SESSION['lang'] ?? 'en'; ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo $site_title_name ." ". translate('solo_pvp_page_title', 'Top 50 Players'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <!-- Font Awesome for icons -->
-    
-    <style>
+// Ensure site settings and translations are loaded for page head config
+require_once $project_root . 'includes/config.settings.php';
+require_once $project_root . 'languages/language.php';
+
+// Page configuration
+$page_title = $site_title_name ." ". translate('solo_pvp_page_title', 'Top 50 Players');
+$page_class = 'armory';
+
+ob_start();
+?>
+<style>
         /* Page background - Show full background image without overlay */
         body {
             background: url('<?php echo $base_path; ?>img/backgrounds/bg-armory.jpg') no-repeat center center fixed;
@@ -406,8 +404,11 @@ function classIcon($class) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+require_once $project_root . 'includes/header.php';
+?>
 <div class="arena-content min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
         <!-- Main Container - Darker Glass Effect -->
@@ -537,5 +538,3 @@ function classIcon($class) {
 </div>
 
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/character.php
+++ b/pages/character.php
@@ -5,20 +5,13 @@ require_once $project_root . 'includes/session.php';
 require_once $project_root . 'languages/language.php';
 require_once $project_root . 'includes/item_tooltip.php';
 $page_class = 'character';
-require_once $project_root . 'includes/header.php';
+require_once $project_root . 'includes/config.settings.php';
+$page_title = $site_title_name . ' ' . translate('page_title', 'Character Equipment');
+$page_meta_description = translate('meta_description', 'View your World of Warcraft character equipment, stats, and PvP details.');
+$page_meta_robots = 'index';
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('meta_description', 'View your World of Warcraft character equipment, stats, and PvP details.'); ?>">
-    <meta name="robots" content="index">
-    <title><?php echo $site_title_name ." ". translate('page_title', 'Character Equipment'); ?></title>
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800;900&family=Cinzel:wght@600;700;900&display=swap" rel="stylesheet">
-    
   <style>
         * { font-family: 'Inter', sans-serif; }
 
@@ -572,8 +565,10 @@ require_once $project_root . 'includes/header.php';
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+require_once $project_root . 'includes/header.php';
+?>
 
 <div class="relative z-10 min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
@@ -1200,5 +1195,3 @@ require_once $project_root . 'includes/header.php';
 </script>
 
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/forgot_password.php
+++ b/pages/forgot_password.php
@@ -10,7 +10,6 @@ require_once $project_root . 'includes/config.cap.php';
 require_once $project_root . 'includes/config.mail.php';
 require_once $project_root . 'languages/language.php';
 $page_class = 'forgot_password';
-require_once $project_root . 'includes/header.php';
 
 // Redirect to account if already logged in
 if (isset($_SESSION['user_id'])) {
@@ -308,21 +307,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
-?>
+$page_title = $site_title_name ." ". translate('page_title', ' - Forgot Password');
+$page_meta_description = translate('meta_description', 'Request a password reset link for your World of Warcraft server account.');
 
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="description" content="<?php echo translate('meta_description', 'Request a password reset link for your World of Warcraft server account.'); ?>">
-    <title><?php echo $site_title_name ." ". translate('page_title', ' - Forgot Password'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
+ob_start();
+?>
     <style>
         /* Page background - Only essential custom CSS */
         body {
@@ -412,8 +401,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+require_once $project_root . 'includes/header.php';
+?>
 <div class="forgot-content relative z-10 min-h-screen flex items-center justify-center px-4 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4 flex items-center justify-center">
         
@@ -483,5 +475,3 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <?php endif; ?>
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/how_to_play.php
+++ b/pages/how_to_play.php
@@ -6,8 +6,10 @@ require_once __DIR__ . '/../includes/paths.php';
 
 // Use $project_root for filesystem includes
 require_once $project_root . 'includes/session.php';
+require_once $project_root . 'languages/language.php';
+require_once $project_root . 'includes/config.settings.php';
 $page_class = "how_to_play";
-require_once $project_root . 'includes/header.php'; 
+$page_title = $site_title_name . translate('how_to_play_title', 'How to Play');
 
 $realmsFile = $project_root . 'includes/realm_config.php';
 $realmlistIP = '127.0.0.1'; // fallback if file missing
@@ -18,6 +20,8 @@ if (file_exists($realmsFile)) {
         $realmlistIP = $realmlist[0]['address'];
     }
 }
+
+ob_start();
 ?>
 
 <style>
@@ -283,6 +287,10 @@ if (file_exists($realmsFile)) {
         .step-badge { width: 32px; height: 32px; font-size: 0.95rem; top: 1rem; left: 1rem; }
     }
 </style>
+<?php
+$page_head = ob_get_clean();
+require_once $project_root . 'includes/header.php';
+?>
 
 <!-- Main Page Wrapper -->
 <div class="relative z-10 min-h-screen flex flex-col">

--- a/pages/login.php
+++ b/pages/login.php
@@ -561,19 +561,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-include_once $project_root . 'includes/header.php';
+$page_title = $site_title_name . " " . translate('page_title', 'Login');
+$page_meta_description = translate('meta_description', 'Log in to your account to join the adventure on our World of Warcraft server!');
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="<?php echo htmlspecialchars(translate('meta_description', 'Log in to your account to join the adventure on our World of Warcraft server!')); ?>" />
-    <title><?php echo $site_title_name . " " . translate('page_title', 'Login'); ?></title>
-
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-
     <style>
         body {
             background: url('<?php echo $base_path; ?>img/backgrounds/bg-login.jpg') no-repeat center center fixed;
@@ -663,9 +655,11 @@ include_once $project_root . 'includes/header.php';
             }
         }
     </style>
-</head>
+<?php
+$page_head = ob_get_clean();
 
-<body>
+include_once $project_root . 'includes/header.php';
+?>
 <div class="login-content relative z-10 min-h-screen flex items-center justify-center px-4 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4 flex items-center justify-center">
         <div class="glass-container p-6 md:p-10">
@@ -784,5 +778,3 @@ include_once $project_root . 'includes/header.php';
 <?php endif; ?>
 
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/news.php
+++ b/pages/news.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../includes/paths.php';
 require_once $project_root . 'includes/session.php';
 require_once $project_root . 'languages/language.php';
 $page_class = 'news';
-include $project_root . 'includes/header.php';
+require_once $project_root . 'includes/config.settings.php';
 
 $default_image_url = 'img/newsimg/news.png';
 $items_per_page = 6;
@@ -33,10 +33,7 @@ if ($is_single) {
 
     if (!$news) {
         header('HTTP/1.0 404 Not Found');
-        echo '<h1>' . translate('error_404_title', '404 - News Not Found') . '</h1>';
-        echo '<p>' . translate('error_404_message', 'The news article you are looking for does not exist.') . '</p>';
-        include $project_root . 'includes/footer.php';
-        exit;
+        $news_not_found = true;
     }
 } else {
     $current_page = isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1;
@@ -98,29 +95,26 @@ $categories = [];
 while ($row = $category_result->fetch_assoc()) {
     $categories[] = $row['category'];
 }
-?>
 
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <?php if ($is_single): ?>
-        <meta name="description" content="<?php echo htmlspecialchars(substr($news['content'], 0, 150)); ?>...">
+// Build page title, meta description and head content before any output
+if ($is_single && !empty($news)) {
+    $page_title = htmlspecialchars($news['title']);
+    $page_meta_description = substr($news['content'], 0, 150) . '...';
+} elseif (!empty($news_not_found)) {
+    $page_title = translate('error_404_title', '404 - News Not Found');
+} else {
+    $page_title = $site_title_name . ' ' . translate('page_title_list', 'News');
+    $page_meta_description = translate('meta_description_list', 'Latest news and updates for our World of Warcraft server.');
+}
+$page_meta_robots = 'index';
+
+ob_start();
+?>
+    <?php if ($is_single && !empty($news)): ?>
         <link rel="canonical" href="<?php echo $base_path; ?>news?slug=<?php echo htmlspecialchars($news['slug']); ?>">
-        <title><?php echo htmlspecialchars($news['title']); ?></title>
-    <?php else: ?>
-        <meta name="description" content="<?php echo translate('meta_description_list', 'Latest news and updates for our World of Warcraft server.'); ?>">
+    <?php elseif (!$is_single): ?>
         <link rel="canonical" href="<?php echo $base_path; ?>news?page=<?php echo $current_page; ?>">
-        <title><?php echo $site_title_name ." ". translate('page_title_list', 'News'); ?></title>
     <?php endif; ?>
-    <meta name="robots" content="index">
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700;900&display=swap" rel="stylesheet">
-    
     <style>
         /* Scrollbar styling */
         ::-webkit-scrollbar { width: 10px; height: 10px; }
@@ -230,8 +224,18 @@ while ($row = $category_result->fetch_assoc()) {
             word-break: break-word;
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+include $project_root . 'includes/header.php';
+
+if (!empty($news_not_found)) {
+    echo '<h1>' . translate('error_404_title', '404 - News Not Found') . '</h1>';
+    echo '<p>' . translate('error_404_message', 'The news article you are looking for does not exist.') . '</p>';
+    include $project_root . 'includes/footer.php';
+    exit;
+}
+?>
 
 <div class="relative z-10 min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
@@ -413,5 +417,3 @@ if (isset($site_db)) {
 }
 include $project_root . 'includes/footer.php'; 
 ?>
-</body>
-</html>

--- a/pages/register.php
+++ b/pages/register.php
@@ -279,22 +279,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
-// Include header after processing form
-include_once $project_root . 'includes/header.php';
+$page_class = 'register';
+$page_title = $site_title_name ." ". translate('page_title', 'Create Account');
+$page_meta_description = translate('meta_description', 'Create an account to join our World of Warcraft server adventure!');
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="description" content="<?php echo translate('meta_description', 'Create an account to join our World of Warcraft server adventure!'); ?>">
-    <title><?php echo $site_title_name ." ". translate('page_title', 'Create Account'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
     <style>
         /* Page background - Show full background image */
         body {
@@ -454,8 +444,12 @@ include_once $project_root . 'includes/header.php';
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+// Include header after processing form
+include_once $project_root . 'includes/header.php';
+?>
 <div class="register-content min-h-screen flex items-center justify-center px-4 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4 flex items-center justify-center">
         
@@ -543,5 +537,3 @@ include_once $project_root . 'includes/header.php';
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <?php endif; ?>
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/resend_activation.php
+++ b/pages/resend_activation.php
@@ -10,8 +10,6 @@ require_once $project_root . 'includes/config.mail.php';
 require_once $project_root . 'includes/config.cap.php'; // reCAPTCHA keys
 require_once $project_root . 'languages/language.php'; // Add for translate()
 $page_class = 'resend_activation'; // Underscore for URL consistency
-require_once $project_root . 'includes/header.php';
-
 
 if (isset($_SESSION['user_id'])) {
     header("Location: {$base_path}account");
@@ -178,21 +176,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 }
-?>
+$page_title = $site_title_name ." ". translate('page_title', 'Resend Activation Email');
+$page_meta_description = translate('meta_description', 'Resend the activation email for your World of Warcraft server account.');
 
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="description" content="<?php echo translate('meta_description', 'Resend the activation email for your World of Warcraft server account.'); ?>">
-    <title><?php echo $site_title_name ." ". translate('page_title', 'Resend Activation Email'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
+ob_start();
+?>
     <style>
         /* Page background - Show full background image */
         body {
@@ -291,8 +279,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+require_once $project_root . 'includes/header.php';
+?>
 <div class="resend-content relative z-10 min-h-screen flex items-center justify-center px-4 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4 flex items-center justify-center">
         
@@ -367,5 +358,3 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <?php endif; ?>
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/reset_password.php
+++ b/pages/reset_password.php
@@ -11,7 +11,6 @@ require_once $project_root . 'includes/srp6.php';
 require_once $project_root . 'includes/config.mail.php';
 require_once $project_root . 'languages/language.php';
 $page_class = 'reset_password';
-require_once $project_root . 'includes/header.php';
 
 if (isset($_SESSION['user_id'])) {
     header("Location: {$base_path}account");
@@ -252,21 +251,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $valid_token) {
         }
     }
 }
-?>
+$page_title = $site_title_name ." ". translate('page_title', 'Reset Password');
+$page_meta_description = translate('meta_description', 'Reset your password for our World of Warcraft server.');
 
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="description" content="<?php echo translate('meta_description', 'Reset your password for our World of Warcraft server.'); ?>">
-    <title><?php echo $site_title_name ." ". translate('page_title', 'Reset Password'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
+ob_start();
+?>
     <style>
         /* Page background - Show full background image */
         body {
@@ -362,8 +351,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $valid_token) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+
+require_once $project_root . 'includes/header.php';
+?>
 <div class="reset-content relative z-10 min-h-screen flex items-center justify-center px-4 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4 flex items-center justify-center">
         
@@ -446,5 +438,3 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $valid_token) {
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <?php endif; ?>
 <?php include_once $project_root . 'includes/footer.php'; ?>
-</body>
-</html>

--- a/pages/shop.php
+++ b/pages/shop.php
@@ -6,7 +6,6 @@ require_once $project_root . 'includes/item_tooltip.php';
 require_once $project_root . 'languages/language.php';
 
 $page_class = 'shop';
-include_once $project_root . 'includes/header.php';
 
 $selected_category = isset($_GET['category']) ? $_GET['category'] : 'All';
 $valid_categories = ['All', 'Service', 'Mount', 'Pet', 'Gold', 'Stuff', 'Set'];
@@ -148,22 +147,14 @@ if (!empty($_SESSION['user_id']) && isset($_SESSION['last_purchase_time'])) {
         $remaining_cooldown = $cooldown_duration - ($current_time - $last_purchase_time);
     }
 }
-?>
 
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="<?php echo translate('shop_meta_description', 'Browse and purchase items, mounts, pets, gold, and services for '.$site_title_name . ' WoW Server'); ?>">
-    <title><?php echo $site_title_name ." ".translate('shop_page_title', '- Shop'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
-    <style>
+$page_class = 'shop';
+$page_title = $site_title_name ." ".translate('shop_page_title', '- Shop');
+$page_meta_description = translate('shop_meta_description', 'Browse and purchase items, mounts, pets, gold, and services for '.$site_title_name . ' WoW Server');
+
+ob_start();
+?>
+<style>
         /* Page background - Show full background image */
         body {
             background: url('<?php echo $base_path; ?>img/backgrounds/bg-shop.jpg') no-repeat center center fixed;
@@ -388,8 +379,10 @@ if (!empty($_SESSION['user_id']) && isset($_SESSION['last_purchase_time'])) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+include_once $project_root . 'includes/header.php';
+?>
 
 <div class="shop-content relative z-10 min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
@@ -602,8 +595,6 @@ if (!empty($_SESSION['user_id']) && isset($_SESSION['last_purchase_time'])) {
     </div>
 </div>
 
-<?php include_once $project_root . 'includes/footer.php'; ?>
-
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Category filtering
@@ -811,8 +802,7 @@ if (!empty($_SESSION['user_id']) && isset($_SESSION['last_purchase_time'])) {
     });
 </script>
 
-</body>
-</html>
+<?php include_once $project_root . 'includes/footer.php'; ?>
 <?php 
 $site_db->close();
 $char_db->close();

--- a/pages/vote.php
+++ b/pages/vote.php
@@ -7,8 +7,7 @@ require_once __DIR__ . '/../includes/paths.php';
 // Use $project_root for filesystem includes
 require_once $project_root . 'includes/config.settings.php';
 require_once $project_root . 'includes/session.php';
-$page_class = 'vote';
-require_once $project_root . 'includes/header.php';
+require_once $project_root . 'languages/language.php';
 
 // Check database connection
 if (!isset($site_db) || !$site_db instanceof mysqli) {
@@ -126,20 +125,13 @@ if (!function_exists('translate')) {
         return $default;
     }
 }
+
+$page_class = 'vote';
+$page_title = $site_title_name ." ". translate('vote_title', 'Vote for Epic Rewards');
+
+ob_start();
 ?>
-<!DOCTYPE html>
-<html lang="<?php echo htmlspecialchars($_SESSION['lang'] ?? 'en', ENT_QUOTES, 'UTF-8'); ?>">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?php echo $site_title_name ." ". translate('vote_title', 'Vote for Epic Rewards'); ?></title>
-    
-    <!-- Tailwind CSS -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>assets/css/tailwind.css">
-    <!-- Font Awesome for icons -->
-    <link rel="stylesheet" href="<?php echo $base_path; ?>node_modules/@fortawesome/fontawesome-free/css/all.min.css">
-    
-    <style>
+<style>
         /* Page background - Lighter vibrant gradient for voting page */
         body {
             background: linear-gradient(135deg, #1a1a2e 0%, #16213e 25%, #0f3460 50%, #533483 75%, #1a1a2e 100%);
@@ -387,8 +379,10 @@ if (!function_exists('translate')) {
             }
         }
     </style>
-</head>
-<body>
+<?php
+$page_head = ob_get_clean();
+require_once $project_root . 'includes/header.php';
+?>
 
 <div class="vote-content min-h-screen flex items-start justify-center px-4 md:px-8 py-8">
     <div class="container mx-auto max-w-7xl px-2 sm:px-4">
@@ -593,8 +587,6 @@ if (!function_exists('translate')) {
     </div>
 </div>
 
-<?php include_once $project_root . 'includes/footer.php'; ?>
-
 <script>
     const basePath = '<?php echo addslashes($base_path); ?>';
 
@@ -743,5 +735,5 @@ if (!function_exists('translate')) {
         };
     });
 </script>
-</body>
-</html>
+
+<?php include_once $project_root . 'includes/footer.php'; ?>

--- a/pages/vote.php
+++ b/pages/vote.php
@@ -510,7 +510,7 @@ require_once $project_root . 'includes/header.php';
                                                   data-site-id="<?php echo (int)$site['id']; ?>" 
                                                   data-remaining-seconds="<?php echo (int)$site['remaining_cooldown']; ?>" 
                                                   data-cooldown-hours="<?php echo (int)$site['cooldown_hours']; ?>">
-                                                <?php echo $site['is_on_cooldown'] ? translate('vote_cooldown_timer', 'Cooldown: Calculating...') : '<span class="text-[#2ecc71] font-semibold"><i class="fas fa-circle-check mr-1"></i>' . translate('vote_cooldown_ready', 'Ready to vote!') . '</span>'; ?>
+                                                <?php echo $site['is_on_cooldown'] ? translate('vote_cooldown_timer', 'Cooldown: Calculating...') : '<span class="text-wow-success font-semibold"><i class="fas fa-circle-check mr-1"></i>' . translate('vote_cooldown_ready', 'Ready to vote!') . '</span>'; ?>
                                             </span>
                                         <?php endif; ?>
                                     </div>
@@ -658,7 +658,7 @@ require_once $project_root . 'includes/header.php';
                 const interval = setInterval(() => {
                     if (remainingSeconds <= 0) {
                         clearInterval(interval);
-                        timer.innerHTML = '<span class="text-[#2ecc71] font-semibold"><i class="fas fa-circle-check mr-1"></i><?php echo translate('vote_cooldown_ready', 'Ready to vote!'); ?></span>';
+                        timer.innerHTML = '<span class="text-wow-success font-semibold"><i class="fas fa-circle-check mr-1"></i><?php echo translate('vote_cooldown_ready', 'Ready to vote!'); ?></span>';
                         const voteCard = timer.closest('.vote-card');
                         const voteBtn = voteCard ? voteCard.querySelector('.vote-btn') : null;
                         if (voteBtn) {


### PR DESCRIPTION
header.php used to render and close a complete HTML document (</body></html>), after which every page rendered its own second <!DOCTYPE html><html><head><body> block. Browsers received two documents in one response: invalid HTML per W3C, cross-browser CSS conflicts, SEO/accessibility parsing issues, and "headers already sent" warnings.

Template architecture refactor:
- header.php now opens the document only; it accepts $page_title, $page_meta_description, $page_meta_robots, $page_head and $page_body_class from the including page and no longer closes </body></html>
- footer.php now closes the document (footer include is always last)
- 33 pages cleaned up: removed redundant DOCTYPE/html//body blocks, page styles moved into <head> via $page_head output buffering, duplicate tailwind/fontawesome/font <link> tags dropped

Also fixed:
- broken redirects that fired after header include: news.php (404 status), forgot_password.php, reset_password.php, resend_activation.php (logged-in redirects) — all moved before any output register.php missing $page_class (transparent auth header never applied)
- armory pages missing $page_class (Armory nav never highlighted)
- admin settings pages: inline body background-image converted to CSS rules (header body tag supports classes, style attr)
- scripts sitting after </html> on anews.php/ashop.php moved inside the document

Verified: php -l on all 33 files, no DOCTYPE outside header.php, no header() calls after the header include.

BREAKING CHANGE: any page including header.php must set $page_title/ $page_head before the include and must not close the document itself; front pages must include footer.php as the last output.